### PR TITLE
Make architecture configurable

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -72,7 +72,7 @@ workspace "SOIL2"
 	location("./make/" .. os.target() .. "/")
 	targetdir("./bin")
 	configurations { "debug", "release" }
-	platforms { "x86", "x86_64" }
+	platforms { "x86_64", "x86" }
 	download_and_extract_dependencies()
 	objdir("obj/" .. os.target() .. "/")
 

--- a/premake5.lua
+++ b/premake5.lua
@@ -72,8 +72,15 @@ workspace "SOIL2"
 	location("./make/" .. os.target() .. "/")
 	targetdir("./bin")
 	configurations { "debug", "release" }
+	platforms { "x86", "x86_64" }
 	download_and_extract_dependencies()
 	objdir("obj/" .. os.target() .. "/")
+
+	filter "platforms:x86"
+		architecture "x86"
+
+	filter "platforms:x86_64"
+		architecture "x86_64"
 
 	project "soil2-static-lib"
 		kind "StaticLib"


### PR DESCRIPTION
Premake 4 had a `--platform` parameter. Premake 5 doesn't have this anymore, instead `architecture` needs to be set via configurations

See
https://github.com/premake/premake-core/wiki/architecture
https://github.com/premake/premake-core/wiki/Configurations-and-Platforms